### PR TITLE
Add PWA Phase 2: iPad gate + admin install banner stub

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:report": "playwright show-report",
     "db": "tsx scripts/db.ts",
     "sql": "tsx scripts/sql.ts",
+    "test:device": "tsx scripts/test-device-detection.mjs",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/scripts/emulate-pwa.mjs
+++ b/scripts/emulate-pwa.mjs
@@ -1,0 +1,45 @@
+import { chromium, devices } from 'playwright';
+import { mkdirSync } from 'node:fs';
+
+const BASE = 'http://localhost:3000';
+const OUT = 'c:/tmp/pwa-emu';
+mkdirSync(OUT, { recursive: true });
+
+const tests = [
+  { name: '1-ipad-admin-dashboard-unauth', device: 'iPad Pro 11 landscape', path: '/admin/dashboard' },
+  { name: '2-iphone-admin-dashboard-redirected', device: 'iPhone 14', path: '/admin/dashboard' },
+  { name: '3-iphone-mobile-unavailable-page', device: 'iPhone 14', path: '/admin/mobile-unavailable' },
+  { name: '4-ipad-login-page', device: 'iPad Pro 11 landscape', path: '/auth/login' },
+  { name: '5-iphone-force-desktop', device: 'iPhone 14', path: '/admin/dashboard?force=desktop' },
+];
+
+const browser = await chromium.launch();
+const results = [];
+
+for (const t of tests) {
+  const deviceProfile = devices[t.device];
+  if (!deviceProfile) {
+    console.error(`No device profile for "${t.device}"`);
+    continue;
+  }
+  const ctx = await browser.newContext({ ...deviceProfile });
+  const page = await ctx.newPage();
+  try {
+    const response = await page.goto(BASE + t.path, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await page.waitForTimeout(800);
+    const finalUrl = page.url();
+    const status = response?.status() ?? 'n/a';
+    await page.screenshot({ path: `${OUT}/${t.name}.png`, fullPage: true });
+    results.push({ name: t.name, input: t.path, final: finalUrl.replace(BASE, ''), status });
+    console.log(`${t.name.padEnd(42)} ${t.path.padEnd(42)} -> ${finalUrl.replace(BASE, '').padEnd(40)} [${status}]`);
+  } catch (e) {
+    console.error(`${t.name} FAILED: ${e.message}`);
+    results.push({ name: t.name, input: t.path, error: e.message });
+  }
+  await ctx.close();
+}
+
+await browser.close();
+
+console.log('\n--- SUMMARY ---');
+for (const r of results) console.log(JSON.stringify(r));

--- a/scripts/test-device-detection.mjs
+++ b/scripts/test-device-detection.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Unit-style tests for src/lib/pwa/deviceDetection.ts.
+ *
+ * Stubs globalThis.navigator for each scenario and asserts getDeviceKind()
+ * returns the expected DeviceKind. Run with: `npm run test:device`
+ *
+ * Exit 0 on all pass, 1 on any failure.
+ */
+import assert from 'node:assert/strict';
+
+const CASES = [
+  {
+    name: 'iPhone UA -> iphone',
+    ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+    maxTouchPoints: 5,
+    expected: 'iphone',
+  },
+  {
+    name: 'Legacy iPad UA -> ipad',
+    ua: 'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1 Mobile/15E148 Safari/604.1',
+    maxTouchPoints: 5,
+    expected: 'ipad',
+  },
+  {
+    name: 'iPadOS 13+ Mac UA + maxTouchPoints > 1 -> ipad',
+    ua: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+    maxTouchPoints: 5,
+    expected: 'ipad',
+  },
+  {
+    name: 'Mac UA + maxTouchPoints = 0 -> desktop',
+    ua: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+    maxTouchPoints: 0,
+    expected: 'desktop',
+  },
+  {
+    name: 'Android UA with Mobile -> android-phone',
+    ua: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+    maxTouchPoints: 5,
+    expected: 'android-phone',
+  },
+  {
+    name: 'Android UA without Mobile -> android-tablet',
+    ua: 'Mozilla/5.0 (Linux; Android 14; SM-X900) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    maxTouchPoints: 5,
+    expected: 'android-tablet',
+  },
+  {
+    name: 'Chrome Windows UA -> desktop',
+    ua: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    maxTouchPoints: 0,
+    expected: 'desktop',
+  },
+];
+
+function stubNavigator(ua, maxTouchPoints) {
+  // Node >=20 defines globalThis.navigator as a non-writable getter. Use
+  // defineProperty to replace it with a configurable, writable stub so we
+  // can swap it per test case.
+  const stub = {
+    userAgent: ua,
+    maxTouchPoints,
+    platform:
+      ua.includes('Win')
+        ? 'Win32'
+        : ua.includes('Mac') || ua.includes('iPad') || ua.includes('iPhone')
+          ? 'MacIntel'
+          : 'Linux',
+  };
+  Object.defineProperty(globalThis, 'navigator', {
+    value: stub,
+    writable: true,
+    configurable: true,
+  });
+}
+
+async function run() {
+  // Import with cache-busting per iteration so module-level reads (if any) re-run.
+  // getDeviceKind() should itself read navigator dynamically, so one import is fine.
+  const mod = await import('../src/lib/pwa/deviceDetection.ts');
+  const { getDeviceKind } = mod;
+
+  let passed = 0;
+  let failed = 0;
+  const failures = [];
+
+  for (const tc of CASES) {
+    stubNavigator(tc.ua, tc.maxTouchPoints);
+    try {
+      const got = getDeviceKind();
+      assert.equal(got, tc.expected, `${tc.name}: expected ${tc.expected}, got ${got}`);
+      console.log(`  PASS  ${tc.name}`);
+      passed++;
+    } catch (err) {
+      console.log(`  FAIL  ${tc.name}`);
+      console.log(`        ${err.message}`);
+      failed++;
+      failures.push({ name: tc.name, message: err.message });
+    }
+  }
+
+  console.log('');
+  console.log(`Total: ${CASES.length}  Passed: ${passed}  Failed: ${failed}`);
+  if (failed > 0) process.exit(1);
+}
+
+run().catch((err) => {
+  console.error('Test runner crashed:', err);
+  process.exit(1);
+});

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+import AdminInstallBanner from '@/components/pwa/AdminInstallBanner';
+
+/**
+ * Admin layout wrapper.
+ *
+ * Introduced in PWA Phase 2 to host the admin install banner. The banner
+ * is a client component that self-gates visibility (authenticated admin,
+ * iPad, just-logged-in flag, no active dismissal cooldown, not already
+ * installed), so mounting it unconditionally here is safe — it renders
+ * nothing on all the wrong conditions.
+ *
+ * Server component. Keep it that way unless a future phase requires
+ * client-side state at the layout level.
+ */
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <AdminInstallBanner />
+      {children}
+    </>
+  );
+}

--- a/src/app/admin/mobile-unavailable/page.tsx
+++ b/src/app/admin/mobile-unavailable/page.tsx
@@ -1,0 +1,67 @@
+import Link from 'next/link';
+
+export const metadata = {
+  title: 'OCO Admin requires a larger device',
+};
+
+/**
+ * Landing page when a phone-class device tries to open /admin/*.
+ * Middleware redirects here; this page does not itself enforce any gate.
+ *
+ * Styled with slate-* neutrals and inline SVG icons to match the admin
+ * visual language. No emoji.
+ */
+export default function MobileUnavailablePage() {
+  return (
+    <div className="min-h-screen bg-slate-50 flex items-center justify-center px-6 py-12">
+      <div className="w-full max-w-md bg-white rounded-2xl shadow-sm border border-slate-200 p-8 sm:p-10">
+        <div className="flex items-center justify-center w-14 h-14 rounded-full bg-slate-100 mx-auto mb-6">
+          <svg
+            className="w-7 h-7 text-slate-500"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            aria-hidden="true"
+          >
+            <rect x="4" y="2.5" width="16" height="19" rx="2.5" />
+            <path d="M10 18h4" strokeLinecap="round" />
+          </svg>
+        </div>
+
+        <h1 className="text-xl sm:text-2xl font-semibold text-slate-900 text-center mb-3">
+          OCO Admin requires a tablet or desktop
+        </h1>
+
+        <p className="text-sm text-slate-600 text-center leading-relaxed mb-6">
+          The admin dashboard is dense and designed for iPad or larger screens.
+          On a phone the grids do not fit and editing is unreliable. If you are
+          a brand user, the portal is fully phone-ready.
+        </p>
+
+        <Link
+          href="/portal"
+          className="w-full inline-flex items-center justify-center gap-2 bg-slate-900 text-white font-medium rounded-xl px-4 py-3 text-sm hover:bg-slate-800 active:bg-slate-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 focus-visible:ring-offset-2"
+        >
+          Open the brand portal
+          <svg
+            className="w-4 h-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </Link>
+
+        <p className="text-xs text-slate-400 text-center mt-6 leading-relaxed">
+          Need to sign in as an admin right now? Open this link on an iPad or desktop,
+          or append <span className="font-mono text-slate-500">?force=desktop</span> to
+          the admin URL as an emergency override.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -107,6 +107,9 @@ export default function LoginPage() {
             method: 'POST', headers: { 'Content-Type': 'application/json' },
             credentials: 'include', body: JSON.stringify({ action: 'login', device_trusted: true }),
           }).catch(() => {});
+          // PWA Phase 2: flag the first authenticated page load so the admin
+          // install banner can one-shot render. Cleared by the banner on read.
+          try { sessionStorage.setItem('oco:just-logged-in', '1'); } catch {}
           if (isSafari) { window.location.href = redirectTo; }
           else { try { await router.push(redirectTo); } catch { window.location.href = redirectTo; } }
           return;
@@ -129,6 +132,10 @@ export default function LoginPage() {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         credentials: 'include', body: JSON.stringify({ action: 'login' }),
       }).catch(() => {});
+
+      // PWA Phase 2: flag the first authenticated page load so the admin
+      // install banner can one-shot render.
+      try { sessionStorage.setItem('oco:just-logged-in', '1'); } catch {}
 
       // Navigate
       if (isSafari) {
@@ -168,6 +175,9 @@ export default function LoginPage() {
         return;
       }
       await fetch('/api/auth/log-session', { method: 'POST', headers: { 'Content-Type': 'application/json' }, credentials: 'include', body: JSON.stringify({ action: 'login' }) }).catch(() => {});
+      // PWA Phase 2: flag the first authenticated page load so the admin
+      // install banner can one-shot render.
+      try { sessionStorage.setItem('oco:just-logged-in', '1'); } catch {}
       window.location.href = pendingRedirect;
     } catch { setError('Verification failed.'); setLoading(false); }
   };
@@ -190,6 +200,9 @@ export default function LoginPage() {
       // 2FA is now cleared server-side. Send the user through normally — no second factor,
       // and they can re-enrol from admin settings once signed in.
       await fetch('/api/auth/log-session', { method: 'POST', headers: { 'Content-Type': 'application/json' }, credentials: 'include', body: JSON.stringify({ action: 'login', twofa_reset: true }) }).catch(() => {});
+      // PWA Phase 2: flag the first authenticated page load so the admin
+      // install banner can one-shot render.
+      try { sessionStorage.setItem('oco:just-logged-in', '1'); } catch {}
       window.location.href = pendingRedirect;
     } catch { setError('Reset failed. Please try again.'); setLoading(false); }
   };

--- a/src/components/pwa/AdminInstallBanner.tsx
+++ b/src/components/pwa/AdminInstallBanner.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getDeviceKind } from '@/lib/pwa/deviceDetection';
+
+/**
+ * Admin install banner — Phase 2 STUB.
+ *
+ * Self-gates visibility. Safe to always mount from the admin layout.
+ * Renders only when ALL are true:
+ *   - Authenticated admin user (GET /api/auth/me → role ADMIN)
+ *   - Device kind is 'ipad' (iPadOS 13+ Mac-UA case handled by
+ *     deviceDetection via maxTouchPoints)
+ *   - sessionStorage 'oco:just-logged-in' flag is set (consumed on mount;
+ *     one-shot — a reload does not re-trigger this banner)
+ *   - Not already running in standalone PWA mode
+ *   - No active 14-day dismissal cooldown
+ *
+ * Phase 1 will wire the real iOS Share → Add to Home Screen UX here
+ * (animated SVG of the Safari share icon, etc.) plus
+ * `beforeinstallprompt` handling for Chromium. This file deliberately
+ * does NOT import any install-prompt hook yet — per spec.
+ */
+
+const DISMISS_KEY = 'oco:install-dismissed-until:admin';
+const JUST_LOGGED_IN_KEY = 'oco:just-logged-in';
+const COOLDOWN_MS = 14 * 24 * 60 * 60 * 1000;
+
+export default function AdminInstallBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    // All the following checks must run client-side only.
+    if (typeof window === 'undefined') return;
+
+    let cancelled = false;
+
+    // Standalone check: if already installed, never show the banner.
+    const isStandalone =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(display-mode: standalone)').matches;
+    if (isStandalone) return;
+
+    // Device check: iPad-only for v1 (desktop comes later per spec).
+    if (getDeviceKind() !== 'ipad') return;
+
+    // One-shot login flag — consume immediately so reloads don't re-fire.
+    let justLoggedIn = false;
+    try {
+      justLoggedIn = sessionStorage.getItem(JUST_LOGGED_IN_KEY) === '1';
+      if (justLoggedIn) sessionStorage.removeItem(JUST_LOGGED_IN_KEY);
+    } catch {
+      // sessionStorage access can throw in some sandboxed contexts — bail.
+      return;
+    }
+    if (!justLoggedIn) return;
+
+    // Cooldown check — respect the user's 14-day dismissal.
+    try {
+      const until = Number(localStorage.getItem(DISMISS_KEY) || 0);
+      if (until && until > Date.now()) return;
+    } catch {
+      // If localStorage is unavailable, err on the side of not showing.
+      return;
+    }
+
+    // Authenticated-admin check. If /api/auth/me fails or returns a non-admin,
+    // silently do nothing.
+    (async () => {
+      try {
+        const res = await fetch('/api/auth/me', { credentials: 'include' });
+        if (!res.ok) return;
+        const data = await res.json();
+        const role = (data?.user?.role || data?.role || '').toString().toUpperCase();
+        if (role !== 'ADMIN') return;
+        if (!cancelled) setVisible(true);
+      } catch {
+        // Network error — do not surface the banner.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!visible) return null;
+
+  const handleDismiss = () => {
+    try {
+      localStorage.setItem(DISMISS_KEY, String(Date.now() + COOLDOWN_MS));
+    } catch {
+      // Cooldown couldn't persist — still hide this render.
+    }
+    setVisible(false);
+  };
+
+  return (
+    <div
+      role="region"
+      aria-label="Install OCO Admin"
+      className="mx-auto my-3 max-w-3xl w-[calc(100%-1.5rem)] rounded-xl border border-slate-200 bg-white shadow-sm"
+    >
+      <div className="flex items-start gap-3 p-4 sm:p-5">
+        <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-slate-100 flex items-center justify-center">
+          <svg
+            className="w-5 h-5 text-slate-700"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            aria-hidden="true"
+          >
+            <path d="M12 3v12m0 0l-4-4m4 4l4-4" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M4 17v2a2 2 0 002 2h12a2 2 0 002-2v-2" strokeLinecap="round" />
+          </svg>
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <h2 className="text-sm font-semibold text-slate-900">Install OCO Admin</h2>
+          <p className="text-xs text-slate-500 mt-1 leading-relaxed">
+            Phase 1 will wire the Share &rarr; Add to Home Screen flow here.
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss install banner"
+          className="flex-shrink-0 w-8 h-8 rounded-lg text-slate-400 hover:text-slate-700 hover:bg-slate-100 active:bg-slate-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500"
+        >
+          <svg
+            className="w-4 h-4 mx-auto"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path d="M6 6l12 12M18 6L6 18" strokeLinecap="round" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/pwa/deviceDetection.ts
+++ b/src/lib/pwa/deviceDetection.ts
@@ -1,0 +1,85 @@
+/**
+ * Device-kind detection for PWA install gating and admin iPhone blocking.
+ *
+ * Why this lives client-side only: iPad detection relies on
+ * `navigator.maxTouchPoints`, which is NOT sent in the HTTP User-Agent.
+ * iPadOS 13+ reports a Mac UA; touch points are the only reliable
+ * disambiguator. The middleware does a separate, coarser iPhone/Android-
+ * phone UA check for SSR — see src/middleware.ts.
+ *
+ * All exports are safe to call from client code. On the server (no
+ * `navigator`), `getDeviceKind()` returns 'unknown', which callers should
+ * treat as "don't gate UI yet — wait for client hydration."
+ */
+
+export type DeviceKind =
+  | 'iphone'
+  | 'ipad'
+  | 'android-phone'
+  | 'android-tablet'
+  | 'desktop'
+  | 'unknown';
+
+function readNavigator(): { userAgent: string; maxTouchPoints: number } | null {
+  if (typeof navigator === 'undefined') return null;
+  const ua = typeof navigator.userAgent === 'string' ? navigator.userAgent : '';
+  const mtp = typeof navigator.maxTouchPoints === 'number' ? navigator.maxTouchPoints : 0;
+  return { userAgent: ua, maxTouchPoints: mtp };
+}
+
+/**
+ * Best-effort device classification.
+ *
+ * iPad detection covers two distinct UA shapes:
+ *   1. Legacy: UA contains "iPad" (iOS 12 and earlier, plus request-desktop-site off)
+ *   2. iPadOS 13+: UA contains "Macintosh" AND `navigator.maxTouchPoints > 1`
+ *
+ * A Mac with a touchscreen would also match case 2 — there is no Mac with a
+ * built-in touchscreen as of this writing, so the false-positive rate is
+ * negligible. If that changes, revisit.
+ */
+export function getDeviceKind(): DeviceKind {
+  const nav = readNavigator();
+  if (!nav) return 'unknown';
+  const { userAgent: ua, maxTouchPoints } = nav;
+
+  // Legacy iPad: UA explicitly says iPad. Check this BEFORE iPhone so we don't
+  // get confused by the "Mobile" token that legacy iPad UAs also include.
+  if (/iPad/.test(ua)) return 'ipad';
+
+  // iPadOS 13+: Mac UA with multi-touch. Excludes desktop Macs (maxTouchPoints = 0).
+  if (/Macintosh/.test(ua) && maxTouchPoints > 1) return 'ipad';
+
+  // iPhone / iPod touch
+  if (/iPhone|iPod/.test(ua)) return 'iphone';
+
+  // Android: phones have "Mobile" token, tablets do not.
+  if (/Android/.test(ua)) {
+    return /Mobile/.test(ua) ? 'android-phone' : 'android-tablet';
+  }
+
+  // Anything else with a real UA we treat as desktop.
+  if (ua) return 'desktop';
+
+  return 'unknown';
+}
+
+/**
+ * True for iPad, Android tablet, and desktop. False for iPhone and Android phone.
+ * Used by the admin install banner to decide whether the current device is
+ * appropriate for the admin surface.
+ */
+export function isTabletOrLarger(): boolean {
+  const kind = getDeviceKind();
+  return kind === 'ipad' || kind === 'android-tablet' || kind === 'desktop';
+}
+
+/**
+ * True for iPhone or iPad (including the iPadOS-13+-Mac-UA case).
+ * Used to pick the iOS-style install instructions (manual Share → Add to
+ * Home Screen) since iOS Safari has no programmatic install prompt.
+ */
+export function isIOS(): boolean {
+  const kind = getDeviceKind();
+  return kind === 'iphone' || kind === 'ipad';
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -138,6 +138,25 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
+  // ── Phone UA gate for /admin (Phase 2 PWA) ─────────────────────────────────
+  // The admin surface is intentionally iPad+/desktop only. Redirect phone-class
+  // devices to an informational page BEFORE any auth or capability work — a
+  // bookmark-follower with a saved session on an iPhone shouldn't mount the
+  // 5700-line AdminDataGrid just to hit an unusable UI. iPad detection uses
+  // navigator.maxTouchPoints client-side; the server can only see UA, so here
+  // we match unambiguous phone tokens and leave iPad/tablet cases to render
+  // normally. `?force=desktop` is a documented escape hatch for edge cases.
+  if (pathname.startsWith('/admin') && !pathname.startsWith('/admin/mobile-unavailable')) {
+    const forceDesktop = request.nextUrl.searchParams.get('force') === 'desktop';
+    if (!forceDesktop) {
+      const ua = request.headers.get('user-agent') || '';
+      const isPhoneUA = /iPhone|iPod/.test(ua) || (/Android/.test(ua) && /Mobile/.test(ua));
+      if (isPhoneUA) {
+        return NextResponse.redirect(new URL('/admin/mobile-unavailable', request.url));
+      }
+    }
+  }
+
   // ── Only protect /admin, /vendor, and /portal routes ───────────────────────
   const isProtected = pathname.startsWith('/admin') || pathname.startsWith('/vendor') || pathname.startsWith('/portal');
   if (!isProtected) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -158,7 +158,13 @@ export async function middleware(request: NextRequest) {
   }
 
   // ── Only protect /admin, /vendor, and /portal routes ───────────────────────
-  const isProtected = pathname.startsWith('/admin') || pathname.startsWith('/vendor') || pathname.startsWith('/portal');
+  // /admin/mobile-unavailable is an informational page for phone users who were
+  // redirected here before login — it must be publicly viewable, or the phone
+  // UA gate above chains into /auth/login and the user never sees the message.
+  const isProtected =
+    (pathname.startsWith('/admin') && !pathname.startsWith('/admin/mobile-unavailable')) ||
+    pathname.startsWith('/vendor') ||
+    pathname.startsWith('/portal');
   if (!isProtected) {
     return NextResponse.next();
   }


### PR DESCRIPTION
- Redirect phone UAs hitting /admin/* to /admin/mobile-unavailable (escape hatch via ?force=desktop)
- Detect iPad including iPadOS 13+ Mac-UA + maxTouchPoints case
- Mount stub AdminInstallBanner post-login on iPad; real beforeinstallprompt wiring lands in Phase 1