### PR TITLE
Fix weekly summary store/visit metric mismatch

### DIFF
--- a/src/components/portal/WeeklySummaryCard.tsx
+++ b/src/components/portal/WeeklySummaryCard.tsx
@@ -91,7 +91,7 @@ function renderMarkdown(md: string) {
 
 export default function WeeklySummaryCard({ summary }: { summary: WeeklySummary | null }) {
   if (!summary) return null;
-  const { storeCount = 0, statusChangeCount = 0 } = summary.stats;
+  const { visitCount = 0, storeCount = 0, statusChangeCount = 0 } = summary.stats;
 
   return (
     <section className="rounded-2xl border border-blue-100 bg-gradient-to-br from-white to-blue-50/40 shadow-sm overflow-hidden">
@@ -112,12 +112,15 @@ export default function WeeklySummaryCard({ summary }: { summary: WeeklySummary 
           <h3 className="text-lg font-bold text-slate-900 mt-0.5">{formatWeekRange(summary.weekOf)}</h3>
         </div>
         <div className="hidden sm:flex items-center gap-3 text-center">
+          <Stat value={visitCount} label={visitCount === 1 ? 'visit' : 'visits'} />
+          <div className="h-8 w-px bg-blue-100" />
           <Stat value={storeCount} label={storeCount === 1 ? 'store' : 'stores'} />
           <div className="h-8 w-px bg-blue-100" />
           <Stat value={statusChangeCount} label="status updates" />
         </div>
       </div>
       <div className="px-5 py-5 sm:hidden flex items-center justify-around border-b border-blue-100/80">
+        <Stat value={visitCount} label={visitCount === 1 ? 'visit' : 'visits'} />
         <Stat value={storeCount} label={storeCount === 1 ? 'store' : 'stores'} />
         <Stat value={statusChangeCount} label="status updates" />
       </div>

--- a/src/lib/weeklyEmail.ts
+++ b/src/lib/weeklyEmail.ts
@@ -99,6 +99,7 @@ export function buildWeeklyEmailHtml(params: {
 }): { html: string; text: string; subject: string } {
   const { brandName, contactName, weekOf, summaryMd, stats, portalUrl } = params;
   const weekRange = formatWeekRange(weekOf);
+  const visitCount = stats.visitCount || 0;
   const storeCount = stats.storeCount || 0;
   const statusChangeCount = stats.statusChangeCount || 0;
 
@@ -150,6 +151,10 @@ export function buildWeeklyEmailHtml(params: {
                 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:12px">
                   <tr>
                     <td align="center" style="padding:14px 8px">
+                      <div style="font-size:20px;font-weight:700;color:#0f172a;line-height:1">${visitCount}</div>
+                      <div style="font-size:10px;text-transform:uppercase;letter-spacing:.08em;color:#64748b;margin-top:4px">${visitCount === 1 ? 'visit' : 'visits'}</div>
+                    </td>
+                    <td align="center" style="padding:14px 8px;border-left:1px solid #e2e8f0">
                       <div style="font-size:20px;font-weight:700;color:#0f172a;line-height:1">${storeCount}</div>
                       <div style="font-size:10px;text-transform:uppercase;letter-spacing:.08em;color:#64748b;margin-top:4px">${storeCount === 1 ? 'store' : 'stores'}</div>
                     </td>

--- a/src/lib/weeklySummary.ts
+++ b/src/lib/weeklySummary.ts
@@ -311,10 +311,14 @@ WHAT TO OMIT (CRITICAL)
 - No meta-framing like "Here's your weekly update" or "This week's summary." Just give them the update.
 
 OPENING
-- Start with a single sentence that sets the scope of the week in a natural, factual way. ALWAYS use digits (e.g. "15", "8", "22") for the visit/store count, not spelled-out words ("fifteen", "eight"). Examples of good first sentences:
-  - "15 store visits across the Twin Cities this week, with a few things worth calling out."
-  - "Quieter week — 8 stops, mostly routine, but one reorder moving at Kowalski's Stillwater."
+- Start with a single sentence that sets the scope of the week in a natural, factual way. ALWAYS use digits (e.g. "15", "8", "22") for counts, not spelled-out words ("fifteen", "eight").
+- The input tells you TWO numbers: the total visit count (how many store visits happened) and the unique store count (how many distinct stores that represents). They may differ — e.g., 15 visits across 10 unique stores when some stores were visited more than once. If they differ, prefer a phrasing that references visits (the activity metric), and optionally mention the unique-store figure for coverage context. NEVER invent or swap these numbers.
+- Examples of good first sentences:
+  - "15 store visits across 10 Twin Cities stores this week, with a few things worth calling out."
+  - "15 visits this week across the Twin Cities — mostly routine, but one reorder moving at Kowalski's Stillwater."
+  - "Quieter week — 8 visits across 7 stores, mostly routine."
   - "Busy stretch: 22 visits, a Target authorization on Chipotle Salsa, and two pricing shifts we're watching."
+- If visits and unique stores are equal (every store visited exactly once), just use one number naturally: "10 visits across the Twin Cities this week…"
 - The opener names the shape of the week. It does not greet anyone.
 
 PROGRESS THIS WEEK (only if there are status changes)
@@ -368,7 +372,7 @@ FORMATTING — CRITICAL
 
 EXAMPLE OUTPUT — follow this structure exactly:
 
-15 store visits across the Twin Cities this week, with a few things worth calling out.
+15 store visits across 10 Twin Cities stores this week, with a few things worth calling out.
 
 **From the field**
 
@@ -384,7 +388,11 @@ function formatDataForPrompt(data: BrandWeekData): string {
   lines.push(`Week: ${data.weekOf} through ${data.weekEnd}`);
   lines.push('');
 
-  lines.push(`Market visits (${data.visits.length}):`);
+  const visitTotal = data.stats.visitCount;
+  const uniqueStores = data.stats.storeCount;
+  lines.push(
+    `Market visits: ${visitTotal} total visit${visitTotal === 1 ? '' : 's'} across ${uniqueStores} unique store${uniqueStores === 1 ? '' : 's'}.`
+  );
   if (data.visits.length === 0) {
     lines.push('  (none)');
   } else {


### PR DESCRIPTION
The "Your Week in Review" card showed "10 STORES" in the sidebar while the AI narrative said "15 store visits" for the same week. Both numbers were accurate to their own source (unique store_name dedupe vs. raw visit rows), but displayed as if they should match.

Surface both metrics instead of picking one:
- Portal card and email now show visits / stores / status updates as three tiles
- formatDataForPrompt passes both visit total and unique-store count explicitly
- System prompt updated with phrasing rules and example showing both figures