### PR TITLE
Fix Market Visit upload failing silently for large photos

### DIFF
--- a/src/components/admin/MarketVisitUpload.tsx
+++ b/src/components/admin/MarketVisitUpload.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useCallback } from 'react';
 import { useBrands } from '@/hooks/useBrands';
 import { extractExifFromFile } from '@/utils/extractExif';
+import { compressImageForUpload } from '@/utils/compressImage';
 import { reverseGeocode } from '@/utils/reverseGeocode';
 import { findNearbyStore } from '@/utils/findNearbyStore';
 import AddressAutocomplete from './AddressAutocomplete';
@@ -219,8 +220,14 @@ export default function MarketVisitUpload({ onUploaded }: MarketVisitUploadProps
     setSubmitting(true);
 
     try {
+      // Downscale before upload so we stay under Vercel's ~4.5MB serverless
+      // payload limit. Mac Chrome saved images and Retina screenshots
+      // regularly exceed that and previously failed with a bare "Upload
+      // failed" (413 HTML → JSON parse failed on the client).
+      const uploadFile = await compressImageForUpload(file);
+
       const fd = new FormData();
-      fd.append('file', file);
+      fd.append('file', uploadFile);
       fd.append('visit_date', visitDate);
       fd.append('brands', JSON.stringify(selectedBrands));
       if (latitude !== null) fd.append('latitude', String(latitude));
@@ -240,7 +247,17 @@ export default function MarketVisitUpload({ onUploaded }: MarketVisitUploadProps
 
       if (!res.ok) {
         let msg = 'Upload failed';
-        try { const data = await res.json(); msg = data.error || msg; } catch { /* non-JSON response */ }
+        let jsonOk = false;
+        try {
+          const data = await res.json();
+          if (data?.error) { msg = data.error; jsonOk = true; }
+        } catch { /* non-JSON response */ }
+        // 413 / Vercel gateway errors return HTML, not JSON. Give the user
+        // a hint about the cause rather than a bare "Upload failed".
+        if (!jsonOk) {
+          if (res.status === 413) msg = 'Photo is too large to upload. Try a smaller image.';
+          else if (res.status >= 500) msg = 'Server error — please try again.';
+        }
         throw new Error(msg);
       }
 
@@ -336,7 +353,7 @@ export default function MarketVisitUpload({ onUploaded }: MarketVisitUploadProps
             <svg className="w-5 h-5 text-amber-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
             </svg>
-            <span>No location data found in this photo. Use your device's location, or enter the store address manually below.</span>
+            <span>No location data found in this photo. Use your device&apos;s location, or enter the store address manually below.</span>
           </div>
           <button
             type="button"

--- a/src/utils/compressImage.ts
+++ b/src/utils/compressImage.ts
@@ -1,0 +1,81 @@
+// Downscale + re-encode images client-side before upload so they fit inside
+// the ~4.5MB serverless payload limit on Vercel. Mac Chrome screenshots and
+// iPhone Live Photos routinely exceed that and caused silent "Upload failed"
+// errors (413 HTML response → JSON parse fails → bare default string).
+//
+// GPS / date must be extracted from the ORIGINAL file before calling this —
+// canvas re-encoding strips EXIF.
+
+export interface CompressOptions {
+  maxEdgePx?: number;   // longest edge after resize
+  quality?: number;     // 0..1 JPEG quality
+  skipUnderBytes?: number; // don't touch small files
+}
+
+const DEFAULTS: Required<CompressOptions> = {
+  maxEdgePx: 2048,
+  quality: 0.85,
+  skipUnderBytes: 2 * 1024 * 1024, // 2MB
+};
+
+export async function compressImageForUpload(
+  file: File,
+  opts: CompressOptions = {},
+): Promise<File> {
+  const { maxEdgePx, quality, skipUnderBytes } = { ...DEFAULTS, ...opts };
+
+  // Small enough already — don't re-encode and lose fidelity.
+  if (file.size <= skipUnderBytes) return file;
+
+  // HEIC/HEIF can't be decoded by HTMLImageElement on Chrome/Firefox.
+  // Safari can, but Safari's HEIC files are usually small anyway. Let
+  // these pass through — if decode fails we also fall back.
+  const mime = file.type.toLowerCase();
+  if (mime.includes('heic') || mime.includes('heif')) return file;
+
+  const objectUrl = URL.createObjectURL(file);
+  try {
+    const img = await loadImage(objectUrl);
+    const { width: w, height: h } = scale(img.naturalWidth, img.naturalHeight, maxEdgePx);
+
+    const canvas = document.createElement('canvas');
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return file;
+    ctx.drawImage(img, 0, 0, w, h);
+
+    const blob = await new Promise<Blob | null>(resolve => {
+      canvas.toBlob(resolve, 'image/jpeg', quality);
+    });
+    if (!blob) return file;
+    // Only swap if we actually got smaller — re-encoding a heavily-compressed
+    // JPEG can sometimes grow. In that case keep the original.
+    if (blob.size >= file.size) return file;
+
+    const baseName = file.name.replace(/\.[^.]+$/, '') || 'photo';
+    return new File([blob], `${baseName}.jpg`, {
+      type: 'image/jpeg',
+      lastModified: file.lastModified,
+    });
+  } catch {
+    return file;
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('decode failed'));
+    img.src = src;
+  });
+}
+
+function scale(srcW: number, srcH: number, maxEdge: number) {
+  if (srcW <= maxEdge && srcH <= maxEdge) return { width: srcW, height: srcH };
+  const ratio = srcW >= srcH ? maxEdge / srcW : maxEdge / srcH;
+  return { width: Math.round(srcW * ratio), height: Math.round(srcH * ratio) };
+}


### PR DESCRIPTION
Mac Chrome saved images (Retina screenshots, full-res JPEGs) routinely exceed Vercel's 4.5MB serverless payload limit. The client allowed up to 10MB, so oversize uploads hit Vercel's gateway and got back a 413 HTML page. res.json() then threw and the UI fell back to a bare "Upload failed" with no hint.

Downscale and re-encode the photo client-side before upload (max 2048px edge, JPEG q=0.85). EXIF GPS/date are already extracted into form fields at file-pick time, so losing EXIF during re-encode is harmless. HEIC is passed through untouched since Chrome/Firefox cannot decode it. Also surface 413/5xx specifically so the user sees a useful message when something does slip through.