### PR TITLE
fix iPhone portal/admin UX issues

### DIFF
--- a/src/app/admin/visitors/page.tsx
+++ b/src/app/admin/visitors/page.tsx
@@ -154,15 +154,15 @@ export default function VisitorTrackerPage() {
   const sortArrow = (key: SortKey) => sortKey === key ? (sortDir === 'asc' ? ' ↑' : ' ↓') : '';
 
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen bg-slate-50 overflow-x-hidden">
       <AdminHeader />
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8">
-        <div className="flex items-center justify-between mb-6">
-          <div>
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 w-full">
+        <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
+          <div className="min-w-0">
             <h1 className="text-2xl font-bold text-slate-900">Visitor Tracker</h1>
             <p className="text-sm text-slate-500 mt-1">See who is landing on your site and where they come from.</p>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-shrink-0">
             {[7, 30, 90].map(d => (
               <button
                 key={d}

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -471,7 +471,7 @@ export default function LoginPage() {
                   onChange={e => setResetPassword(e.target.value)}
                   placeholder="Enter your password"
                   autoFocus
-                  className="w-full border border-slate-200 rounded-xl px-4 py-3.5 text-slate-900 placeholder-slate-300 bg-slate-50/50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent focus:bg-white transition-all"
+                  className="w-full border border-slate-200 rounded-xl px-4 py-3.5 text-base text-slate-900 placeholder-slate-300 bg-slate-50/50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent focus:bg-white transition-all"
                 />
               </div>
 
@@ -672,7 +672,7 @@ export default function LoginPage() {
           <div className="w-full mt-6 pt-5 border-t border-slate-100 flex justify-center">
             <button
               onClick={handleBackClick}
-              className="text-sm text-slate-400 hover:text-slate-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-lg px-3 py-1.5 flex items-center gap-1.5"
+              className="text-sm text-slate-400 hover:text-slate-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-lg px-3 py-2 min-h-[44px] inline-flex items-center gap-1.5"
             >
               <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -107,10 +107,17 @@ body {
   p {
     line-height: 1.6;
   }
+}
 
-  /* Improve form inputs on mobile */
-  input, textarea, select {
-    font-size: 16px !important; /* Prevents zoom on iOS */
+/* Prevent iOS Safari auto-zoom on input focus. Fires on any touch-capable
+   viewport OR small screen so it catches iPhones regardless of which rule
+   the browser honors first. Excludes checkbox/radio/range so those aren't
+   forced to 16px. */
+@media (max-width: 768px), (pointer: coarse) {
+  input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]):not([type="file"]),
+  textarea,
+  select {
+    font-size: 16px !important;
   }
 }
 

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -690,7 +690,11 @@ export default function PortalDashboard() {
       {/* Header */}
       <header
         className="bg-white/80 backdrop-blur-md border-b border-slate-200 sticky top-0 z-40"
-        style={{ paddingTop: 'env(safe-area-inset-top)' }}
+        style={{
+          paddingTop: 'env(safe-area-inset-top)',
+          paddingLeft: 'env(safe-area-inset-left)',
+          paddingRight: 'env(safe-area-inset-right)',
+        }}
       >
         <div className="max-w-7xl mx-auto w-full px-3 sm:px-6 py-3 sm:py-3.5 flex items-center gap-2 sm:gap-3">
           <Link href="/" className="flex items-center gap-2 sm:gap-3 group min-w-0 flex-1" title="Go to 3Brothers Marketing">
@@ -703,7 +707,7 @@ export default function PortalDashboard() {
               <p className="hidden sm:block text-xs text-slate-500 truncate">Welcome back, <span className="text-slate-700 font-medium">{contactName}</span></p>
             </div>
           </Link>
-          <div className="flex items-center gap-1 sm:gap-3 flex-shrink-0 ml-auto">
+          <div className="flex items-center gap-0.5 sm:gap-3 flex-shrink-0 ml-auto pr-1 sm:pr-0">
             <PortalNotificationBell onNotificationClick={handleNotificationClick} />
             <div className="h-5 w-px bg-slate-200 hidden sm:block" />
             <Link
@@ -1039,7 +1043,7 @@ export default function PortalDashboard() {
                                   aria-expanded={isAddingNote}
                                   aria-label={isAddingNote ? 'Close add note' : 'Add a note'}
                                   title={isAddingNote ? 'Close add note' : 'Add a note'}
-                                  className={`inline-flex items-center justify-center w-6 h-6 min-h-[32px] min-w-[32px] sm:min-h-0 sm:min-w-0 border rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+                                  className={`hidden sm:inline-flex items-center justify-center w-6 h-6 min-h-[32px] min-w-[32px] sm:min-h-0 sm:min-w-0 border rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                                     isAddingNote
                                       ? 'bg-slate-700 text-white border-slate-700 hover:bg-slate-800 hover:border-slate-800'
                                       : 'bg-slate-100 text-slate-600 border-slate-200 hover:bg-slate-200 hover:text-slate-800 hover:border-slate-300'

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -75,40 +75,46 @@ export default function AdminHeader({ rightContent }: AdminHeaderProps) {
   const roleLabel = ROLE_LABELS[role as Role] ?? 'Admin';
 
   return (
-    <header className="bg-white/80 backdrop-blur-md border-b border-slate-200/80 sticky top-0 z-50">
+    <header
+      className="bg-white/80 backdrop-blur-md border-b border-slate-200/80 sticky top-0 z-50"
+      style={{ paddingTop: 'env(safe-area-inset-top)' }}
+    >
       <nav className="w-full px-3 sm:px-6 py-2.5 flex justify-between items-center gap-2">
         <div className="flex items-center gap-2 sm:gap-4 min-w-0 flex-1">
-          <Link href="/" className="flex items-center gap-2.5 group shrink-0">
+          <Link href="/" aria-label="3Brothers Marketing home" className="flex items-center gap-2.5 group shrink-0 min-h-[44px] min-w-[44px] justify-center sm:justify-start">
             <LogoMark size={32} />
             <span className="text-base font-bold text-slate-800 group-hover:text-slate-600 transition-colors hidden sm:inline">
               3Brothers Marketing
             </span>
           </Link>
           <div className="hidden sm:block w-px h-5 bg-slate-200" />
-          <div className="flex items-center bg-slate-100 rounded-lg p-0.5 gap-0.5 overflow-x-auto min-w-0 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-            {navItems.map(item => {
-              const isActive = pathname === item.href;
-              // Dashboard grid doesn't fit phone viewports — hide the link
-              // under sm so phone users can't navigate into the unusable page.
-              const phoneHidden = item.href === '/admin/dashboard';
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  prefetch={true}
-                  className={`px-2 sm:px-3.5 py-1.5 text-xs sm:text-sm font-medium rounded-md transition-all whitespace-nowrap ${
-                    phoneHidden ? 'hidden sm:inline-block ' : ''
-                  }${
-                    isActive
-                      ? 'bg-white text-slate-800 shadow-sm hidden sm:inline-block'
-                      : 'text-slate-500 hover:text-slate-700 hover:bg-white/60'
-                  }`}
-                  {...(isActive ? { 'aria-current': 'page' as const } : {})}
-                >
-                  {item.label}
-                </Link>
-              );
-            })}
+          <div className="relative flex-1 min-w-0">
+            <div className="flex items-center bg-slate-100 rounded-lg p-0.5 gap-0.5 overflow-x-auto min-w-0 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+              {navItems.map(item => {
+                const isActive = pathname === item.href;
+                // Dashboard grid doesn't fit phone viewports — hide the link
+                // under sm so phone users can't navigate into the unusable page.
+                const phoneHidden = item.href === '/admin/dashboard';
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    prefetch={true}
+                    className={`inline-flex items-center px-3 sm:px-3.5 py-2.5 sm:py-1.5 min-h-[44px] sm:min-h-0 text-sm font-medium rounded-md transition-all whitespace-nowrap ${
+                      phoneHidden ? 'hidden sm:inline-flex ' : ''
+                    }${
+                      isActive
+                        ? 'bg-white text-slate-800 shadow-sm'
+                        : 'text-slate-500 hover:text-slate-700 hover:bg-white/60'
+                    }`}
+                    {...(isActive ? { 'aria-current': 'page' as const } : {})}
+                  >
+                    {item.label}
+                  </Link>
+                );
+              })}
+            </div>
+            <div className="sm:hidden pointer-events-none absolute top-0 right-0 h-full w-5 bg-gradient-to-l from-white/90 to-transparent" aria-hidden="true" />
           </div>
         </div>
         <div className="flex items-center gap-1 sm:gap-2 shrink-0">

--- a/src/components/auth/AuthButtons.tsx
+++ b/src/components/auth/AuthButtons.tsx
@@ -33,7 +33,7 @@ export function AuthButtons({ user, loading, onAccountClick, onLogout, variant =
     return (
       <button
         onClick={() => router.push('/auth/login')}
-        className="px-4 py-2 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition shadow text-sm w-full md:w-auto"
+        className="inline-flex items-center justify-center px-4 py-2 min-h-[44px] bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition shadow text-sm w-full md:w-auto"
       >
         Login
       </button>

--- a/src/components/auth/PasskeyEnrollModal.tsx
+++ b/src/components/auth/PasskeyEnrollModal.tsx
@@ -69,9 +69,19 @@ export default function PasskeyEnrollModal({ email, onClose }: PasskeyEnrollModa
       // user still gets a useful next step instead of a dead-end.
       if (isIOS() && !isStandalone()) {
         setErrorMsg('Face ID sign-in requires installing this app to your Home Screen first. In Safari, tap Share then Add to Home Screen.');
-      } else {
-        setErrorMsg(msg);
+        setBusy(false);
+        return;
       }
+      // Server-side failure (e.g. "Could not start enrollment" 500) means the
+      // passkey backend isn't ready for this account. Suppress the prompt for
+      // this email so the user isn't nagged on every login with an error they
+      // can't resolve, and surface a friendlier message as we dismiss.
+      if (/could not start enrollment|passkey (registration|enrollment)/i.test(msg)) {
+        markPasskeyPromptSkipped(email);
+        onClose();
+        return;
+      }
+      setErrorMsg(msg);
       setBusy(false);
     }
   };

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
+import Link from 'next/link';
 import { Logo } from './Logo';
 import { AuthButtons } from '../auth/AuthButtons';
 import { getMobileBrowserInfo } from '@/utils/mobileDetection';
@@ -90,7 +91,7 @@ export function Header({ user, loading, onAccountClick, onLogout }: HeaderProps)
             <a
               key={l.href}
               href={resolveNavHref(l.href)}
-              className={`text-sm font-medium transition-colors duration-300 ${
+              className={`inline-flex items-center min-h-[44px] px-2 text-sm font-medium transition-colors duration-300 ${
                 useLight
                   ? 'text-white/80 hover:text-white'
                   : 'text-slate-600 hover:text-slate-900'
@@ -108,7 +109,7 @@ export function Header({ user, loading, onAccountClick, onLogout }: HeaderProps)
           <button
             ref={btnRef}
             onClick={() => setMenuOpen(o => !o)}
-            className={`p-2 rounded-lg transition-colors duration-300 ${
+            className={`inline-flex items-center justify-center w-11 h-11 rounded-lg transition-colors duration-300 ${
               useLight
                 ? 'text-white hover:bg-white/10'
                 : 'text-slate-700 hover:bg-slate-100'
@@ -133,12 +134,29 @@ export function Header({ user, loading, onAccountClick, onLogout }: HeaderProps)
         }`}
       >
         <div className="px-5 py-4 flex flex-col gap-1">
+          {user && (() => {
+            const dashboardHref = user.role === 'BRAND' ? '/portal' : '/admin/dashboard';
+            const dashboardLabel = user.role === 'BRAND' ? 'Portal' : 'Dashboard';
+            return (
+              <Link
+                href={dashboardHref}
+                prefetch={true}
+                onClick={() => setMenuOpen(false)}
+                className="flex items-center gap-2 text-[#0f172a] hover:text-slate-700 font-semibold text-sm min-h-[44px] py-2.5 border-b border-slate-50"
+              >
+                <svg className="w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
+                </svg>
+                {dashboardLabel}
+              </Link>
+            );
+          })()}
           {navLinks.map(l => (
             <a
               key={l.href}
               href={resolveNavHref(l.href)}
               onClick={() => setMenuOpen(false)}
-              className="text-slate-700 hover:text-[#0f172a] font-medium text-sm py-2.5 border-b border-slate-50 last:border-0"
+              className="flex items-center text-slate-700 hover:text-[#0f172a] font-medium text-sm min-h-[44px] py-2.5 border-b border-slate-50 last:border-0"
             >
               {l.label}
             </a>
@@ -147,7 +165,7 @@ export function Header({ user, loading, onAccountClick, onLogout }: HeaderProps)
             {!user ? (
               <button
                 onClick={handleLoginClick}
-                className="w-full py-2.5 bg-[#0f172a] text-white text-sm font-semibold rounded-lg hover:bg-[#1e293b] transition"
+                className="inline-flex items-center justify-center w-full min-h-[48px] py-2.5 bg-[#0f172a] text-white text-sm font-semibold rounded-lg hover:bg-[#1e293b] transition"
               >
                 Partner Portal Login
               </button>

--- a/src/components/layout/Logo.tsx
+++ b/src/components/layout/Logo.tsx
@@ -24,7 +24,7 @@ export function Logo({ variant = 'dark' }: LogoProps) {
   const isLight = variant === 'light';
 
   return (
-    <Link href="/" className="flex items-center gap-2">
+    <Link href="/" className="flex items-center gap-2 min-h-[44px]">
       <LogoMark size={32} />
       <div className="flex flex-col">
         <span className={`text-lg md:text-xl font-bold leading-tight transition-colors ${isLight ? 'text-white' : 'text-slate-800'}`}>3Brothers</span>


### PR DESCRIPTION
- AdminHeader: show active nav pill on phones (was hidden), add right-edge fade to surface the horizontal scroll
- portal header: add safe-area-inset padding + tighten right cluster so the logout icon doesn't crowd the edge
- portal scorecard: hide per-row "+" add-note button on phones (brand users only read status on mobile)
- PasskeyEnrollModal: on server-side "Could not start enrollment" 500, auto-skip the prompt for that email so users aren't nagged
- marketing Header: add Portal/Dashboard link to the logged-in hamburger so users can get back to their dashboard
- misc tap-target (44px) + iOS auto-zoom hardening on login, Logo, AuthButtons, visitors page