### PR TITLE
fix(portal): iPhone drawer whitespace on real iOS PWA

### DIFF
--- a/src/app/portal/PortalCommentDrawer.tsx
+++ b/src/app/portal/PortalCommentDrawer.tsx
@@ -1332,11 +1332,10 @@ export default function PortalCommentDrawer({
 
   return (
     <div
-      className="fixed inset-x-0 top-0 h-[100dvh] z-50 flex flex-col sm:flex-row"
+      className="fixed inset-0 z-50 flex flex-col justify-end sm:flex-row"
       role="dialog"
       aria-modal="true"
       aria-label={`Activity for ${retailerName}`}
-      style={{ paddingTop: 'env(safe-area-inset-top)' }}
     >
       <div
         className="absolute inset-0 bg-black bg-opacity-40 transition-opacity"
@@ -1345,7 +1344,7 @@ export default function PortalCommentDrawer({
       />
       <div
         ref={drawerRef}
-        className="relative ml-auto w-full sm:max-w-md bg-white shadow-2xl flex flex-col border-slate-200 mt-auto sm:mt-0 sm:h-full h-[92dvh] max-h-full sm:rounded-none rounded-t-2xl sm:border-l border-t sm:border-t-0 sheet-slide-up sm:animate-slideInRight overflow-hidden"
+        className="relative ml-auto w-full sm:max-w-md bg-white shadow-2xl flex flex-col border-slate-200 sm:h-full max-h-[92svh] sm:max-h-none sm:rounded-none rounded-t-2xl sm:border-l border-t sm:border-t-0 sheet-slide-up sm:animate-slideInRight overflow-hidden"
         style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
       >
         {/* Mobile drag handle */}


### PR DESCRIPTION
## Bug

Opening the comment drawer on a real iPhone (PWA or Safari) produced a giant blank whitespace - either content hidden behind the iOS bottom toolbar, or (after the first fix attempt on `cous-fix`) all content pinned to the bottom third of the screen with the top two-thirds of the drawer empty.

Desktop Chrome iPhone emulation showed no problem, making this hard to reproduce without a real device.

## Failed prior attempt (`cous-fix`)

Changed the outer container from `fixed left-0 right-0 bottom-0 top-0` ? `fixed inset-x-0 top-0 h-[100dvh]`, and the drawer from `max-h-[92dvh]` ? `max-h-full`. This still broke on real iOS because:

- The outer container had `h-[100dvh]` plus `paddingTop: env(safe-area-inset-top)`, reducing the available flex space to `100dvh - safe-area-top`
- The drawer used `h-[92dvh]` sized off the raw viewport (ignoring the padding), so `mt-auto` mis-calculated the gap

## Root cause

`dvh` (dynamic viewport height) fluctuates as iOS browser chrome shows/hides. Mixing `padding-top` on the flex container with `h-[92dvh]` on the flex child creates a unit mismatch - the child is sized from a different reference than the available flex space. `mt-auto` then computes an incorrect gap, displacing the entire sheet.

## Fix (2 lines)

**Outer container** (line 1335):
- `fixed inset-x-0 top-0 h-[100dvh] flex flex-col` ? `fixed inset-0 flex flex-col justify-end`
- Removed `style={{ paddingTop: 'env(safe-area-inset-top)' }}`
- `inset-0` fills the visual viewport natively; `justify-end` pushes the drawer to the bottom without needing `mt-auto`

**Drawer sheet** (line 1347):
- Removed `mt-auto sm:mt-0 h-[92dvh] max-h-full`
- Added `max-h-[92svh] sm:max-h-none`
- `svh` = smallest viewport height - stable, never grows, falls back safely to `vh` on iOS <15.4. `max-h` (not `h`) lets the drawer shrink for short content. `sm:max-h-none` removes the cap on the desktop sidebar.
- `paddingBottom: env(safe-area-inset-bottom)` kept on the drawer for home-indicator clearance

## Scope

This branch carries all commits from `cous-fix` (PortalCommentDrawer, PortalAuthGuard, portal page rewrite, admin improvements) plus this single two-line CSS fix on top.