### PR TITLE
fix(portal): keyboard-aware iOS drawer (superior fix)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -147,7 +147,11 @@ export default async function RootLayout({
   return (
     <html lang="en">
       <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+        {/* `interactive-widget=resizes-content` (iOS 16.4+, Chrome 108+) makes the
+            software keyboard shrink the layout viewport so 100dvh tracks the visible
+            area when the keyboard is up. Older iOS ignores it — the comment drawers
+            fall back to a visualViewport effect. */}
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content" />
         <link rel="icon" href="/logo.png" type="image/png" />
         <link rel="apple-touch-icon" href={m.appleIcon} />
         <link rel="manifest" href={m.manifest} />

--- a/src/app/portal/PortalCommentDrawer.tsx
+++ b/src/app/portal/PortalCommentDrawer.tsx
@@ -1224,6 +1224,35 @@ export default function PortalCommentDrawer({
     return () => window.removeEventListener('keydown', onKey);
   }, [open]);
 
+  // iOS Safari keyboard tracking. The outer container uses `100dvh`, which
+  // already tracks URL-bar show/hide on iOS 15.4+. But on iOS <16.4 the
+  // software keyboard does NOT shrink the layout viewport, so 100dvh stays
+  // full-height and the composer gets buried. We detect that via
+  // visualViewport and override `--drawer-h` to the visible pixel height.
+  useEffect(() => {
+    if (!open) return;
+    const root = drawerRef.current?.parentElement as HTMLElement | null;
+    if (!root) return;
+    const vv = (typeof window !== 'undefined') ? window.visualViewport : null;
+    if (!vv) return;
+    const sync = () => {
+      const delta = window.innerHeight - vv.height;
+      if (delta > 80) {
+        root.style.setProperty('--drawer-h', `${vv.height}px`);
+      } else {
+        root.style.removeProperty('--drawer-h');
+      }
+    };
+    sync();
+    vv.addEventListener('resize', sync);
+    vv.addEventListener('scroll', sync);
+    return () => {
+      vv.removeEventListener('resize', sync);
+      vv.removeEventListener('scroll', sync);
+      root.style.removeProperty('--drawer-h');
+    };
+  }, [open]);
+
   const handleAdd = async () => {
     if (addingRef.current) return;
     if (!commentInput.trim()) return;
@@ -1331,11 +1360,20 @@ export default function PortalCommentDrawer({
   const composerDisabled = isAddingComment || !commentInput.trim();
 
   return (
+    // Height resolution order (first the browser understands wins):
+    //   1. inline `height: var(--drawer-h, 100dvh)` — modern iOS/Chrome. The
+    //      visualViewport effect above sets --drawer-h while the iOS keyboard
+    //      is up; otherwise 100dvh tracks the URL bar.
+    //   2. `h-screen` (100vh) class fallback for iOS <15.4, which doesn't
+    //      parse `dvh` and drops the inline declaration.
+    // Drawer child uses `h-[92%]` so it scales with the container — no unit
+    // mismatch between outer height and drawer height.
     <div
-      className="fixed inset-0 z-50 flex flex-col justify-end sm:flex-row"
+      className="fixed inset-x-0 bottom-0 z-50 flex flex-col sm:flex-row h-screen"
       role="dialog"
       aria-modal="true"
       aria-label={`Activity for ${retailerName}`}
+      style={{ height: 'var(--drawer-h, 100dvh)' }}
     >
       <div
         className="absolute inset-0 bg-black bg-opacity-40 transition-opacity"
@@ -1344,7 +1382,7 @@ export default function PortalCommentDrawer({
       />
       <div
         ref={drawerRef}
-        className="relative ml-auto w-full sm:max-w-md bg-white shadow-2xl flex flex-col border-slate-200 sm:h-full max-h-[92svh] sm:max-h-none sm:rounded-none rounded-t-2xl sm:border-l border-t sm:border-t-0 sheet-slide-up sm:animate-slideInRight overflow-hidden"
+        className="relative ml-auto w-full sm:max-w-md bg-white shadow-2xl flex flex-col border-slate-200 mt-auto sm:mt-0 h-[92%] sm:h-full max-h-full sm:rounded-none rounded-t-2xl sm:border-l border-t sm:border-t-0 sheet-slide-up sm:animate-slideInRight overflow-hidden"
         style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
       >
         {/* Mobile drag handle */}

--- a/src/components/admin/CommentDrawer.tsx
+++ b/src/components/admin/CommentDrawer.tsx
@@ -1228,6 +1228,33 @@ export function SimpleCommentDrawer() {
     getCurrentData, editingScoreCard, comments, selectedCategory,
   } = useAdminGrid();
   const clientLogos = useClientLogos();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // iOS Safari keyboard handling — see PortalCommentDrawer for full rationale.
+  // Admin subtracts 56px (top-14) so the drawer stays below the sticky header.
+  useEffect(() => {
+    if (openCommentRowId === null) return;
+    const root = containerRef.current;
+    if (!root) return;
+    const vv = (typeof window !== 'undefined') ? window.visualViewport : null;
+    if (!vv) return;
+    const sync = () => {
+      const delta = window.innerHeight - vv.height;
+      if (delta > 80) {
+        root.style.setProperty('--drawer-h', `${vv.height - 56}px`);
+      } else {
+        root.style.removeProperty('--drawer-h');
+      }
+    };
+    sync();
+    vv.addEventListener('resize', sync);
+    vv.addEventListener('scroll', sync);
+    return () => {
+      vv.removeEventListener('resize', sync);
+      vv.removeEventListener('scroll', sync);
+      root.style.removeProperty('--drawer-h');
+    };
+  }, [openCommentRowId]);
 
   if (openCommentRowId === null) return null;
 
@@ -1240,12 +1267,17 @@ export function SimpleCommentDrawer() {
   const summary = computeSummary(rowComments);
 
   return (
-    // Drawer sits below the sticky AdminHeader (~56px tall, z-50) so the
-    // breadcrumb/title aren't clipped by the main nav.
-    <div className="fixed left-0 right-0 bottom-0 top-14 z-40 flex flex-col sm:flex-row">
+    // Drawer sits below the sticky AdminHeader (~56px / top-14, z-50). Height
+    // uses `var(--drawer-h, calc(100dvh - 3.5rem))` (tracks URL-bar + keyboard)
+    // with a `calc(100vh - 3.5rem)` class fallback for iOS <15.4.
+    <div
+      ref={containerRef}
+      className="fixed left-0 right-0 bottom-0 z-40 flex flex-col sm:flex-row h-[calc(100vh-3.5rem)]"
+      style={{ height: 'var(--drawer-h, calc(100dvh - 3.5rem))' }}
+    >
       <div className="absolute inset-0 bg-black bg-opacity-40 transition-opacity" onClick={handleCloseCommentModal}></div>
       <div
-        className="relative ml-auto w-full sm:max-w-md bg-white shadow-2xl flex flex-col border-slate-200 mt-auto sm:mt-0 sm:h-full h-[92vh] max-h-[92dvh] rounded-t-2xl sm:rounded-t-none sm:rounded-l-2xl sm:border-l border-t sm:border-t-0 sheet-slide-up sm:animate-slideInRight"
+        className="relative ml-auto w-full sm:max-w-md bg-white shadow-2xl flex flex-col border-slate-200 mt-auto sm:mt-0 sm:h-full h-[92%] max-h-full rounded-t-2xl sm:rounded-t-none sm:rounded-l-2xl sm:border-l border-t sm:border-t-0 sheet-slide-up sm:animate-slideInRight"
         style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
       >
         <div className="sm:hidden pt-2 pb-1 flex justify-center">
@@ -1324,6 +1356,32 @@ export function RetailerDrawer() {
   const [isAddingRetailerComment, setIsAddingRetailerComment] = useState(false);
   const addingRetailerRef = useRef(false);
   const clientLogos = useClientLogos();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // iOS keyboard handling — mirror of SimpleCommentDrawer above.
+  useEffect(() => {
+    if (openRetailerDrawer === null) return;
+    const root = containerRef.current;
+    if (!root) return;
+    const vv = (typeof window !== 'undefined') ? window.visualViewport : null;
+    if (!vv) return;
+    const sync = () => {
+      const delta = window.innerHeight - vv.height;
+      if (delta > 80) {
+        root.style.setProperty('--drawer-h', `${vv.height - 56}px`);
+      } else {
+        root.style.removeProperty('--drawer-h');
+      }
+    };
+    sync();
+    vv.addEventListener('resize', sync);
+    vv.addEventListener('scroll', sync);
+    return () => {
+      vv.removeEventListener('resize', sync);
+      vv.removeEventListener('scroll', sync);
+      root.style.removeProperty('--drawer-h');
+    };
+  }, [openRetailerDrawer]);
 
   if (openRetailerDrawer === null || !selectedCategory || !isScorecard(selectedCategory)) return null;
 
@@ -1428,12 +1486,16 @@ export function RetailerDrawer() {
   const summary = computeSummary(rowComments);
 
   return (
-    // Drawer sits below the sticky AdminHeader (~56px tall, z-50) so the
-    // breadcrumb/title aren't clipped by the main nav.
-    <div className="fixed left-0 right-0 bottom-0 top-14 z-40 flex flex-col sm:flex-row">
+    // Drawer sits below the sticky AdminHeader (~56px / top-14, z-50). See
+    // SimpleCommentDrawer above for the height-resolution rationale.
+    <div
+      ref={containerRef}
+      className="fixed left-0 right-0 bottom-0 z-40 flex flex-col sm:flex-row h-[calc(100vh-3.5rem)]"
+      style={{ height: 'var(--drawer-h, calc(100dvh - 3.5rem))' }}
+    >
       <div className="absolute inset-0 bg-black bg-opacity-40 transition-opacity" onClick={() => setOpenRetailerDrawer(null)}></div>
       <div
-        className="relative ml-auto w-full sm:max-w-md bg-white shadow-2xl flex flex-col border-slate-200 mt-auto sm:mt-0 sm:h-full h-[92vh] max-h-[92dvh] rounded-t-2xl sm:rounded-t-none sm:rounded-l-2xl sm:border-l border-t sm:border-t-0 sheet-slide-up sm:animate-slideInRight"
+        className="relative ml-auto w-full sm:max-w-md bg-white shadow-2xl flex flex-col border-slate-200 mt-auto sm:mt-0 sm:h-full h-[92%] max-h-full rounded-t-2xl sm:rounded-t-none sm:rounded-l-2xl sm:border-l border-t sm:border-t-0 sheet-slide-up sm:animate-slideInRight"
         style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
       >
         <div className="sm:hidden pt-2 pb-1 flex justify-center">


### PR DESCRIPTION
## Summary

Replaces the simpler `inset-0 + justify-end + 92svh` approach from [PR #77](https://github.com/ozkan33/OCO/pull/77) with a more robust keyboard-aware strategy that works correctly on all iOS versions.

### What changed

- **`src/app/layout.tsx`** — adds `interactive-widget=resizes-content` to the viewport meta tag (iOS 16.4+/Chrome 108+). Older iOS ignores it and falls back to the JS approach below.

- **`src/app/portal/PortalCommentDrawer.tsx`** — outer shell switches to `fixed inset-x-0 bottom-0 h-screen` with `height: var(--drawer-h, 100dvh)` inline. A `visualViewport` effect with an 80px delta threshold writes `--drawer-h` only when the keyboard is actually up (not URL-bar show/hide which is ~50px). Inner sheet uses `h-[92%]`.

- **`src/components/admin/CommentDrawer.tsx`** — same pattern for both `SimpleCommentDrawer` and `RetailerDrawer`, minus 56px for the sticky admin header: `var(--drawer-h, calc(100dvh - 3.5rem))`.

### Why this is better than #77

PR #77 used `max-h-[92svh]` which does not account for the keyboard on iOS <16.4 — the composer gets buried behind it. The `visualViewport` listener clamps the drawer height to the actual visible area and restores it cleanly on dismiss. The 80px threshold prevents reacting to URL-bar scroll (~50px), avoiding jarring layout jumps.

## Test plan

- [ ] iPhone (iOS 15-17) PWA: tap composer, keyboard opens, drawer + composer fully visible
- [ ] iOS 16.4+: `interactive-widget=resizes-content` handles it natively
- [ ] Admin iPad: 56px subtraction keeps drawer below sticky header
- [ ] iPhone scroll: URL bar animates, drawer height does NOT jump
- [ ] Desktop: both drawers render at full sidebar height, unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)